### PR TITLE
Fix de handler DeleteAlbum

### DIFF
--- a/model/album.js
+++ b/model/album.js
@@ -10,8 +10,26 @@ class Album{
         return this.id === anId;
     }
 
+    getTracks(){
+        return this.tracks;
+    }
+
     addTrack(aTrack){
         this.tracks.push(aTrack);
+    }
+
+    deleteTrack(nameTrack){
+        let indexToDelete= this.tracks.findIndex(this.isTheTrack(anAlbumName));
+        if(indexToDelete >= 0){
+            this.tracks.splice(indexToDelete,1);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    isTheTrack(aTrackName){
+        return x => x.name === aTrackName;
     }
 
     containsInName(aWord){

--- a/model/artist.js
+++ b/model/artist.js
@@ -16,6 +16,10 @@ class Artist{
         this.albums.push(anAlbum);
     }
 
+    getAlbumByName(anAlbumName){
+        return this.albums.find(this.isTheAlbum(anAlbumName));
+    }
+
     deleteAlbum(anAlbumName){
         let indexToDelete= this.albums.findIndex(this.isTheAlbum(anAlbumName));
         if(indexToDelete >= 0){

--- a/unqfy/unqfy.js
+++ b/unqfy/unqfy.js
@@ -36,11 +36,19 @@ class UNQfy {
     }
 
     deleteAlbumFrom(artistName, albumNameToDelete){
+        let successful;
         let artist= this.artistService.getArtistByName(artistName);
         if(!artist){
-            return console.log("No existe un artista con ese nombre")
+            successful=false;
         }else{
-            return artist.deleteAlbum(albumNameToDelete);
+            let album = artist.getAlbumByName(albumNameToDelete);
+            if(!album){
+                successful= false;
+            }else{
+                this.deleteTracksFromPlayslists(album.getTracks());
+                successful= artist.deleteAlbum(albumNameToDelete);
+            }
+        return successful;
         }
     }
 


### PR DESCRIPTION
- Fix de handler Delete Album para eliminar tracks de ese album de las playlists.

Detalles que faltan:
- Agregarle a los handlers la verificacion que esta recibiendo los parametros minimos (para que por ejemplo no diga que no existe un album de nombre undefined)
- Refactor general de handlers para hacerlos mas eficientes.